### PR TITLE
Refactoring of storage traits

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,3 @@ keywords = ["blockchain", "cryptocurrencies", "fuel-vm", "vm"]
 license = "Apache-2.0"
 repository = "https://github.com/FuelLabs/fuel-storage"
 description = "Storage traits for Fuel storage-backed data structures."
-
-[dependencies]
-auto_impl = "1.0"

--- a/src/impls.rs
+++ b/src/impls.rs
@@ -1,0 +1,102 @@
+use crate::{
+    Mappable, MerkleRoot, MerkleRootStorage, Storage, StorageAsMut, StorageAsRef, StorageError,
+    StorageInspect, StorageMut, StorageMutate, StorageRef,
+};
+use alloc::borrow::Cow;
+
+impl<'a, T: StorageError<Type> + ?Sized, Type: Mappable> StorageError<Type> for &'a T {
+    type Error = T::Error;
+}
+impl<'a, T: StorageError<Type> + ?Sized, Type: Mappable> StorageError<Type> for &'a mut T {
+    type Error = T::Error;
+}
+
+impl<'a, T: StorageInspect<Type> + ?Sized, Type: Mappable> StorageInspect<Type> for &'a T {
+    fn get(&self, key: &Type::Key) -> Result<Option<Cow<'_, Type::GetValue>>, Self::Error> {
+        <T as StorageInspect<Type>>::get(self, key)
+    }
+
+    fn contains_key(&self, key: &Type::Key) -> Result<bool, Self::Error> {
+        <T as StorageInspect<Type>>::contains_key(self, key)
+    }
+}
+
+impl<'a, T: StorageInspect<Type> + ?Sized, Type: Mappable> StorageInspect<Type> for &'a mut T {
+    fn get(&self, key: &Type::Key) -> Result<Option<Cow<'_, Type::GetValue>>, Self::Error> {
+        <T as StorageInspect<Type>>::get(self, key)
+    }
+
+    fn contains_key(&self, key: &Type::Key) -> Result<bool, Self::Error> {
+        <T as StorageInspect<Type>>::contains_key(self, key)
+    }
+}
+
+impl<'a, T: StorageMutate<Type> + ?Sized, Type: Mappable> StorageMutate<Type> for &'a mut T {
+    fn insert(
+        &mut self,
+        key: &Type::Key,
+        value: &Type::SetValue,
+    ) -> Result<Option<Type::GetValue>, Self::Error> {
+        <T as StorageMutate<Type>>::insert(self, key, value)
+    }
+
+    fn remove(&mut self, key: &Type::Key) -> Result<Option<Type::GetValue>, Self::Error> {
+        <T as StorageMutate<Type>>::remove(self, key)
+    }
+}
+
+impl<'a, T: MerkleRootStorage<Key, Type> + ?Sized, Key, Type: Mappable> MerkleRootStorage<Key, Type>
+    for &'a mut T
+{
+    fn root(&mut self, key: &Key) -> Result<MerkleRoot, Self::Error> {
+        <T as MerkleRootStorage<Key, Type>>::root(self, key)
+    }
+}
+
+impl<T: StorageMutate<Type> + StorageInspect<Type>, Type: Mappable> Storage<Type> for T {}
+
+impl<'a, T, Error> StorageAsRef<Error> for T {}
+
+impl<'a, T: StorageAsRef<Error>, Error> StorageAsMut<Error> for T {}
+
+impl<'a, T: StorageInspect<Type>, Type: Mappable> StorageRef<'a, T, Type> {
+    #[inline(always)]
+    pub fn get(self, key: &Type::Key) -> Result<Option<Cow<'a, Type::GetValue>>, T::Error> {
+        self.0.get(key)
+    }
+
+    #[inline(always)]
+    pub fn contains_key(self, key: &Type::Key) -> Result<bool, T::Error> {
+        self.0.contains_key(key)
+    }
+}
+
+impl<'a, T: StorageInspect<Type>, Type: Mappable> StorageMut<'a, T, Type> {
+    #[inline(always)]
+    pub fn get(self, key: &Type::Key) -> Result<Option<Cow<'a, Type::GetValue>>, T::Error> {
+        // Workaround, because compiler doesn't convert the lifetime to `'a` by default.
+        let self_: &'a T = self.0;
+        self_.get(key)
+    }
+
+    #[inline(always)]
+    pub fn contains_key(self, key: &Type::Key) -> Result<bool, T::Error> {
+        self.0.contains_key(key)
+    }
+}
+
+impl<'a, T: StorageMutate<Type>, Type: Mappable> StorageMut<'a, T, Type> {
+    #[inline(always)]
+    pub fn insert(
+        self,
+        key: &Type::Key,
+        value: &Type::SetValue,
+    ) -> Result<Option<Type::GetValue>, T::Error> {
+        self.0.insert(key, value)
+    }
+
+    #[inline(always)]
+    pub fn remove(self, key: &Type::Key) -> Result<Option<Type::GetValue>, T::Error> {
+        self.0.remove(key)
+    }
+}

--- a/src/impls.rs
+++ b/src/impls.rs
@@ -100,3 +100,13 @@ impl<'a, T: StorageMutate<Type>, Type: Mappable> StorageMut<'a, T, Type> {
         self.0.remove(key)
     }
 }
+
+impl<'a, T: Storage<Type>, Type: Mappable> StorageMut<'a, T, Type> {
+    #[inline(always)]
+    pub fn root<Key>(self, key: &Key) -> Result<MerkleRoot, T::Error>
+    where
+        T: MerkleRootStorage<Key, Type>
+    {
+        self.0.root(key)
+    }
+}

--- a/src/impls.rs
+++ b/src/impls.rs
@@ -1,17 +1,12 @@
 use crate::{
-    Mappable, MerkleRoot, MerkleRootStorage, Storage, StorageAsMut, StorageAsRef, StorageError,
+    Mappable, MerkleRoot, MerkleRootStorage, StorageAsMut, StorageAsRef,
     StorageInspect, StorageMut, StorageMutate, StorageRef,
 };
 use alloc::borrow::Cow;
 
-impl<'a, T: StorageError<Type> + ?Sized, Type: Mappable> StorageError<Type> for &'a T {
-    type Error = T::Error;
-}
-impl<'a, T: StorageError<Type> + ?Sized, Type: Mappable> StorageError<Type> for &'a mut T {
-    type Error = T::Error;
-}
-
 impl<'a, T: StorageInspect<Type> + ?Sized, Type: Mappable> StorageInspect<Type> for &'a T {
+    type Error = T::Error;
+
     fn get(&self, key: &Type::Key) -> Result<Option<Cow<'_, Type::GetValue>>, Self::Error> {
         <T as StorageInspect<Type>>::get(self, key)
     }
@@ -22,6 +17,8 @@ impl<'a, T: StorageInspect<Type> + ?Sized, Type: Mappable> StorageInspect<Type> 
 }
 
 impl<'a, T: StorageInspect<Type> + ?Sized, Type: Mappable> StorageInspect<Type> for &'a mut T {
+    type Error = T::Error;
+
     fn get(&self, key: &Type::Key) -> Result<Option<Cow<'_, Type::GetValue>>, Self::Error> {
         <T as StorageInspect<Type>>::get(self, key)
     }
@@ -53,11 +50,9 @@ impl<'a, T: MerkleRootStorage<Key, Type> + ?Sized, Key, Type: Mappable> MerkleRo
     }
 }
 
-impl<T: StorageMutate<Type> + StorageInspect<Type>, Type: Mappable> Storage<Type> for T {}
+impl<'a, T> StorageAsRef for T {}
 
-impl<'a, T, Error> StorageAsRef<Error> for T {}
-
-impl<'a, T: StorageAsRef<Error>, Error> StorageAsMut<Error> for T {}
+impl<'a, T> StorageAsMut for T {}
 
 impl<'a, T: StorageInspect<Type>, Type: Mappable> StorageRef<'a, T, Type> {
     #[inline(always)]
@@ -101,7 +96,7 @@ impl<'a, T: StorageMutate<Type>, Type: Mappable> StorageMut<'a, T, Type> {
     }
 }
 
-impl<'a, T: Storage<Type>, Type: Mappable> StorageMut<'a, T, Type> {
+impl<'a, T: StorageMutate<Type>, Type: Mappable> StorageMut<'a, T, Type> {
     #[inline(always)]
     pub fn root<Key>(self, key: &Key) -> Result<MerkleRoot, T::Error>
     where

--- a/src/impls.rs
+++ b/src/impls.rs
@@ -1,5 +1,5 @@
 use crate::{
-    Mappable, MerkleRoot, MerkleRootStorage, StorageAsMut, StorageAsRef, StorageInspect,
+    Mappable, MerkleRoot, MerkleRootStorage, StorageInspect,
     StorageMut, StorageMutate, StorageRef,
 };
 use alloc::borrow::Cow;
@@ -49,10 +49,6 @@ impl<'a, T: MerkleRootStorage<Key, Type> + ?Sized, Key, Type: Mappable> MerkleRo
         <T as MerkleRootStorage<Key, Type>>::root(self, key)
     }
 }
-
-impl<'a, T> StorageAsRef for T {}
-
-impl<'a, T> StorageAsMut for T {}
 
 impl<'a, T: StorageInspect<Type>, Type: Mappable> StorageRef<'a, T, Type> {
     #[inline(always)]

--- a/src/impls.rs
+++ b/src/impls.rs
@@ -1,6 +1,5 @@
 use crate::{
-    Mappable, MerkleRoot, MerkleRootStorage, StorageInspect,
-    StorageMut, StorageMutate, StorageRef,
+    Mappable, MerkleRoot, MerkleRootStorage, StorageInspect, StorageMut, StorageMutate, StorageRef,
 };
 use alloc::borrow::Cow;
 

--- a/src/impls.rs
+++ b/src/impls.rs
@@ -1,6 +1,6 @@
 use crate::{
-    Mappable, MerkleRoot, MerkleRootStorage, StorageAsMut, StorageAsRef,
-    StorageInspect, StorageMut, StorageMutate, StorageRef,
+    Mappable, MerkleRoot, MerkleRootStorage, StorageAsMut, StorageAsRef, StorageInspect,
+    StorageMut, StorageMutate, StorageRef,
 };
 use alloc::borrow::Cow;
 

--- a/src/impls.rs
+++ b/src/impls.rs
@@ -105,7 +105,7 @@ impl<'a, T: Storage<Type>, Type: Mappable> StorageMut<'a, T, Type> {
     #[inline(always)]
     pub fn root<Key>(self, key: &Key) -> Result<MerkleRoot, T::Error>
     where
-        T: MerkleRootStorage<Key, Type>
+        T: MerkleRootStorage<Key, Type>,
     {
         self.0.root(key)
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -128,13 +128,16 @@ pub trait StorageAsRef {
     }
 }
 
+impl<'a, T> StorageAsRef for T {}
+
 /// The wrapper around the storage that supports methods from `StorageInspect` and `StorageMutate`.
 pub struct StorageMut<'a, T: 'a + ?Sized, Type: Mappable>(
     &'a mut T,
     core::marker::PhantomData<Type>,
 );
 
-/// Helper trait for `StorageMutate` to provide user-friendly API to retrieve storage as mutable reference.
+/// Helper trait for `StorageMutate` to provide user-friendly API to retrieve storage as mutable
+/// reference.
 ///
 /// # Example
 ///
@@ -175,3 +178,5 @@ pub trait StorageAsMut {
         StorageMut(self, Default::default())
     }
 }
+
+impl<'a, T> StorageAsMut for T {}


### PR DESCRIPTION
Refactored traits aim to simplify the usage of traits in the code and add composability. Improve the code's readability by using one generic like `Storage<CoinsTable>`.

What was done:
- Removed usage of `auto_trait`(implemented traits manually).
- Split the `Storage` trait on too traits `StorageInspect` and `StorageMutate`.
- Added `StorageAsRef` and `StorageAsMut` traits to simplify the usage in case of multiple `Storage` implementations.
- Removed `Storage` functionality from `MerkleStorage`.
- Renamed `MerkleStorage` to `MerkleRootStorage`.
- Use one generic in the storage trait to describe all types.
- Added `SetValue` type and `GetValue` type for performance optimization.